### PR TITLE
Inventory Image support alongside FontAwesome support

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -1,10 +1,18 @@
+local QBCore = exports['qb-core']:GetCoreObject()
+
 local headerShown = false
 local sendData = nil
 
 -- Functions
-
 local function openMenu(data)
     if not data or not next(data) then return end
+	for k,v in pairs(data) do 
+		if v["icon"] then
+			if QBCore.Shared.Items[tostring(v["icon"])] then 
+				v["icon"] = "qb-inventory/html/images/"..QBCore.Shared.Items[tostring(v["icon"])].image
+			end
+		end
+	end
     SetNuiFocus(true, true)
     headerShown = false
     sendData = data

--- a/client/main.lua
+++ b/client/main.lua
@@ -8,8 +8,12 @@ local function openMenu(data)
     if not data or not next(data) then return end
 	for k,v in pairs(data) do 
 		if v["icon"] then
-			if QBCore.Shared.Items[tostring(v["icon"])] then 
-				v["icon"] = "qb-inventory/html/images/"..QBCore.Shared.Items[tostring(v["icon"])].image
+			local img = "lj-inventory/html/"
+			if QBCore.Shared.Items[tostring(v["icon"])] then
+				if not string.find(QBCore.Shared.Items[tostring(v["icon"])].image, "images/") then 
+					img = img.."images/"
+				end
+				v["icon"] = img..QBCore.Shared.Items[tostring(v["icon"])].image
 			end
 		end
 	end

--- a/html/script.js
+++ b/html/script.js
@@ -27,7 +27,7 @@ const openMenu = (data = null) => {
 const getButtonRender = (header, message = null, id, isMenuHeader, isDisabled, icon) => {
     return `
         <div class="${isMenuHeader ? "title" : "button"} ${isDisabled ? "disabled" : ""}" id="${id}">
-            <div class="icon"> <i class="${icon}"></i> </div>
+            <div class="icon"> <img src=nui://${icon} width=30px onerror="this.onerror=null; this.remove();"> <i class="${icon}" onerror="this.onerror=null; this.remove();"></i> </div>
             <div className="column">
             <div class="header"> ${header}</div>
             ${message ? `<div class="text">${message}</div>` : ""}


### PR DESCRIPTION
If `icon = "fas fa-circle-xmark"` it'll show the fontawesome icon

If `icon = "lockpick"` and that string is found as an item in the shared it'll load the image

It will only do one of these and it will find one or the other. And hide the "broken" one.

This is the same if nothing is added, it just hides the attempted loading of an icon